### PR TITLE
Documentation and fixes for `substrait_sort()`

### DIFF
--- a/R/expression.R
+++ b/R/expression.R
@@ -21,7 +21,8 @@ as_substrait.quosure <- function(x, .ptype = NULL, ..., compiler = SubstraitComp
         result
       } else {
         substrait$SortField$create(
-          expr = as_substrait(result, "substrait.Expression")
+          expr = as_substrait(result, "substrait.Expression"),
+          direction = "SORT_DIRECTION_ASC_NULLS_LAST"
         )
       }
     },

--- a/man/substrait_sort.Rd
+++ b/man/substrait_sort.Rd
@@ -7,7 +7,7 @@
 \usage{
 substrait_sort(.compiler, ...)
 
-substrait_sort_field(expr, direction = "SORT_DIRECTION_UNSPECIFIED")
+substrait_sort_field(expr, direction = "SORT_DIRECTION_ASC_NULLS_LAST")
 }
 \arguments{
 \item{.compiler}{A \code{\link[=substrait_compiler]{substrait_compiler()}} or object that can be coerced to one}

--- a/tests/testthat/test-expression.R
+++ b/tests/testthat/test-expression.R
@@ -86,7 +86,8 @@ test_that("quosures can be translated to SortFields", {
     substrait$SortField$create(
       expr = substrait$Expression$create(
         literal = substrait$Expression$Literal$create(i32 = 5L)
-      )
+      ),
+      direction = "SORT_DIRECTION_ASC_NULLS_LAST"
     )
   )
 


### PR DESCRIPTION
- Documents the `substrait_sort_field()` wrapper and why it's needed
- Fixes #118 (by changing the default sort direction from "unspecified" to "ascending with nulls last"

``` r
library(dplyr, warn.conflicts = FALSE)
library(substrait, warn.conflicts = FALSE)

mtcars %>%
  duckdb_substrait_compiler() %>%
  arrange(hp) %>%
  collect()
#> # A tibble: 32 × 11
#>      mpg   cyl  disp    hp  drat    wt  qsec    vs    am  gear  carb
#>    <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
#>  1  30.4     4  75.7    52  4.93  1.62  18.5     1     1     4     2
#>  2  24.4     4 147.     62  3.69  3.19  20       1     0     4     2
#>  3  33.9     4  71.1    65  4.22  1.84  19.9     1     1     4     1
#>  4  32.4     4  78.7    66  4.08  2.2   19.5     1     1     4     1
#>  5  27.3     4  79      66  4.08  1.94  18.9     1     1     4     1
#>  6  26       4 120.     91  4.43  2.14  16.7     0     1     5     2
#>  7  22.8     4 108      93  3.85  2.32  18.6     1     1     4     1
#>  8  22.8     4 141.     95  3.92  3.15  22.9     1     0     4     2
#>  9  21.5     4 120.     97  3.7   2.46  20.0     1     0     3     1
#> 10  18.1     6 225     105  2.76  3.46  20.2     1     0     3     1
#> # … with 22 more rows
```

<sup>Created on 2022-05-18 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>