### PR TITLE
Raise error when call transmute() with unsupported args

### DIFF
--- a/R/pkg-dplyr.R
+++ b/R/pkg-dplyr.R
@@ -79,7 +79,7 @@ mutate.SubstraitCompiler <- function(.data, ...) {
 #' @export
 transmute.SubstraitCompiler <- function(.data, ...) {
 
-  dplyr:::check_transmute_args(...)
+  check_transmute_args(...)
   substrait_project(.data, ...)
 }
 
@@ -122,4 +122,16 @@ expr_replace_desc <- function(expr) {
 
 simulate_data_frame <- function(compiler) {
   from_substrait(compiler$schema, data.frame())
+}
+
+check_transmute_args <- function(..., .keep, .before, .after, error_call = rlang::caller_env()){
+    if (!missing(.keep)) {
+        abort("The `.keep` argument is not supported.", call = error_call)
+    }
+    if (!missing(.before)) {
+        abort("The `.before` argument is not supported.", call = error_call)
+    }
+    if (!missing(.after)) {
+        abort("The `.after` argument is not supported.", call = error_call)
+    }
 }

--- a/R/pkg-dplyr.R
+++ b/R/pkg-dplyr.R
@@ -78,6 +78,8 @@ mutate.SubstraitCompiler <- function(.data, ...) {
 #' @importFrom dplyr transmute
 #' @export
 transmute.SubstraitCompiler <- function(.data, ...) {
+
+  dplyr:::check_transmute_args(...)
   substrait_project(.data, ...)
 }
 

--- a/tests/testthat/test-arrow-dplyr-mutate.R
+++ b/tests/testthat/test-arrow-dplyr-mutate.R
@@ -117,7 +117,6 @@ test_that("transmute with unnamed expressions", {
 })
 
 test_that("transmute() with unsupported arguments", {
-  skip("https://github.com/voltrondata/substrait-r/issues/58")
 
   expect_error(
     example_data %>%

--- a/tests/testthat/test-arrow-dplyr-mutate.R
+++ b/tests/testthat/test-arrow-dplyr-mutate.R
@@ -118,26 +118,26 @@ test_that("transmute with unnamed expressions", {
 
 test_that("transmute() with unsupported arguments", {
 
-  expect_error(
-    example_data %>%
-      arrow_substrait_compiler() %>%
+  compare_dplyr_error(
+    .input %>%
       transmute(int = int + 42L, .keep = "all"),
     "`transmute()` does not support the `.keep` argument",
-    fixed = TRUE
+    fixed = TRUE,
+    example_data
   )
-  expect_error(
-    example_data %>%
-      arrow_substrait_compiler() %>%
+  compare_dplyr_error(
+    .input %>%
       transmute(int = int + 42L, .before = lgl),
     "`transmute()` does not support the `.before` argument",
-    fixed = TRUE
+    fixed = TRUE,
+    example_data
   )
-  expect_error(
-    example_data %>%
-      arrow_substrait_compiler() %>%
+  compare_dplyr_error(
+    .input %>%
       transmute(int = int + 42L, .after = chr),
     "`transmute()` does not support the `.after` argument",
-    fixed = TRUE
+    fixed = TRUE,
+    example_data
   )
 })
 


### PR DESCRIPTION
Fixes #58 and now raises error when we call `transmute()` with experimental `mutate()` arguments that `transmute()` doesn't support.
``` r
library(dplyr, warn.conflicts = FALSE)
library(substrait, warn.conflicts = FALSE)
library(arrow, warn.conflicts = FALSE)
#> Some features are not enabled in this build of Arrow. Run `arrow_info()` for more information.

mtcars %>%
  transmute(hp = hp + 1, .keep = "all") %>%
  collect()
#> Error in `transmute()`:
#> ! The `.keep` argument is not supported.

mtcars %>%
  duckdb_substrait_compiler() %>%
  transmute(hp = hp + 1, .keep = "all") %>%
  collect()
#> Error in `transmute()`:
#> ! The `.keep` argument is not supported.


mtcars %>%
  arrow_substrait_compiler() %>%
  transmute(hp = hp + 1, .keep = "all") %>%
  collect()
#> Error in `transmute()`:
#> ! The `.keep` argument is not supported.
```

<sup>Created on 2022-05-20 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>

