### PR TITLE
Improve `substrait_project()` evaluation

### DIFF
--- a/R/aggregate-rel.R
+++ b/R/aggregate-rel.R
@@ -15,10 +15,6 @@ substrait_aggregate <- function(.compiler, ...) {
   .compiler <- substrait_compiler(.compiler)$clone()
 
   quos <- rlang::enquos(..., .named = TRUE)
-  context <- list(
-    schema = .compiler$schema,
-    list_of_expressions = .compiler$mask
-  )
 
   # have to rethink this because we need to keep track of a
   # post_mutate step for expressions like sum(x) + 1
@@ -27,7 +23,6 @@ substrait_aggregate <- function(.compiler, ...) {
     as_substrait,
     .ptype = "substrait.AggregateRel.Measure",
     compiler = .compiler,
-    context = context,
     template = substrait$AggregateFunction$create()
   )
 

--- a/R/aggregate-rel.R
+++ b/R/aggregate-rel.R
@@ -85,17 +85,11 @@ substrait_group_by <- function(.compiler, ...) {
     return(.compiler)
   }
 
-  context <- list(
-    schema = .compiler$schema,
-    list_of_expressions = .compiler$mask
-  )
-
   .compiler$groups <- lapply(
     quos,
     as_substrait,
     .ptype = "substrait.Expression",
-    compiler = .compiler,
-    context = context
+    compiler = .compiler
   )
 
   .compiler

--- a/R/filter-rel.R
+++ b/R/filter-rel.R
@@ -21,17 +21,11 @@ substrait_filter <- function(.compiler, ...) {
     quos <- rlang::quos(TRUE)
   }
 
-  context <- list(
-    schema = .compiler$schema,
-    list_of_expressions = .compiler$mask
-  )
-
   expressions <- lapply(
     quos,
     as_substrait,
     .ptype = "substrait.Expression",
-    compiler = .compiler,
-    context = context
+    compiler = .compiler
   )
 
   combined_expressions_quo <- Reduce("combine_expressions_and", expressions)

--- a/R/project-rel.R
+++ b/R/project-rel.R
@@ -46,7 +46,12 @@ substrait_project <- function(.compiler, ...) {
   .compiler$rel <- rel
   .compiler$schema$names <- names(expressions)
   .compiler$schema$struct_$types <- types
-  .compiler$mask <- expressions
+
+  .compiler$mask <- lapply(
+    seq_along(types) - 1L,
+    simple_integer_field_reference
+  )
+  names(.compiler$mask) <- names(types)
 
   .compiler$validate()
 }

--- a/R/project-rel.R
+++ b/R/project-rel.R
@@ -16,11 +16,6 @@
 substrait_project <- function(.compiler, ...) {
   .compiler <- substrait_compiler(.compiler)$clone()
 
-  context <- list(
-    schema = .compiler$schema,
-    list_of_expressions = .compiler$mask
-  )
-
   # evaluate expressions sequentially, updating the compiler as we go so that
   # fields created by earlier arguments are accessible from later arguments
   quos <- rlang::enquos(..., .named = TRUE)

--- a/R/project-rel.R
+++ b/R/project-rel.R
@@ -21,20 +21,34 @@ substrait_project <- function(.compiler, ...) {
     list_of_expressions = .compiler$mask
   )
 
-  expressions <- lapply(
-    rlang::enquos(..., .named = TRUE),
-    as_substrait,
-    .ptype = "substrait.Expression",
-    compiler = .compiler
-  )
+  # evaluate expressions sequentially, updating the compiler as we go so that
+  # fields created by earlier arguments are accessible from later arguments
+  quos <- rlang::enquos(..., .named = TRUE)
+  expressions <- list()
+  types <- list()
 
-  types <- lapply(
-    expressions,
-    as_substrait,
-    .ptype = "substrait.Type",
-    compiler = .compiler
-  )
+  for (i in seq_along(quos)) {
+    # do the evaluation and calculate the output type
+    name <- names(quos)[i]
+    value <- as_substrait(
+      quos[[i]],
+      .ptype = "substrait.Expression",
+      compiler = .compiler
+    )
+    type <- as_substrait(value, .ptype = "substrait.Type", compiler = .compiler)
 
+    # update the compiler
+    .compiler$mask[[name]] <- value
+    .compiler$schema$names <- union(.compiler$schema$names, name)
+    .compiler$schema$struct_$types[[match(name, .compiler$schema$names)]] <-
+      type
+
+    # keep track of the new expressions and types
+    expressions[[name]] <- value
+    types[[name]] <- type
+  }
+
+  # create the relation with the new expressions and types
   rel <- substrait$Rel$create(
     project = substrait$ProjectRel$create(
       input = .compiler$rel,
@@ -47,6 +61,7 @@ substrait_project <- function(.compiler, ...) {
   .compiler$schema$names <- names(expressions)
   .compiler$schema$struct_$types <- types
 
+  # reset the mask
   .compiler$mask <- lapply(
     seq_along(types) - 1L,
     simple_integer_field_reference

--- a/R/sort-rel.R
+++ b/R/sort-rel.R
@@ -21,11 +21,6 @@ substrait_sort <- function(.compiler, ...) {
 
   quos <- rlang::enquos(...)
 
-  context <- list(
-    schema = .compiler$schema,
-    list_of_expressions = .compiler$mask
-  )
-
   # Rather than an expression, the SortRel needs a list of SortFields,
   # each of which is an Expression + a sort direction. Rather than use
   # desc(), which is specific to dplyr and only lets us specify one
@@ -47,8 +42,7 @@ substrait_sort <- function(.compiler, ...) {
     with_inlined_sort_field,
     as_substrait,
     .ptype = "substrait.SortField",
-    compiler = .compiler,
-    context = context
+    compiler = .compiler
   )
 
   rel <- substrait$Rel$create(

--- a/man/substrait-package.Rd
+++ b/man/substrait-package.Rd
@@ -4,8 +4,7 @@
 \name{substrait-package}
 \title{substrait: 'Substrait' Cross-Language Serialization for Relational Algebra}
 \description{
-Provides an R interface to the 'Substrait' cross-language
-  serialization for relational algebra.
+Provides an R interface to the 'Substrait' cross-language serialization for relational algebra.
 }
 \author{
 \strong{Maintainer}: Dewey Dunnington \email{dewey@fishandwhistle.net} (\href{https://orcid.org/0000-0002-9415-4582}{ORCID})

--- a/tests/testthat/test-filter-rel.R
+++ b/tests/testthat/test-filter-rel.R
@@ -1,0 +1,27 @@
+
+test_that("substrait_filter() appends a FilterRel to a compiler", {
+  tbl <- data.frame(col1 = 1, col2 = "one")
+  compiler <- substrait_compiler(tbl)
+
+  result <- substrait_filter(compiler)
+
+  expect_s3_class(result, "SubstraitCompiler")
+
+  # check that we did append a FilterRel
+  expect_identical(
+    result$rel$filter$input,
+    compiler$rel
+  )
+
+  # check that the filter expression is a literal TRUE
+  expect_identical(
+    result$rel$filter$condition,
+    substrait$Expression$create(
+      literal = substrait$Expression$Literal$create(boolean = TRUE)
+    )
+  )
+
+  # check that nothing else about the compiler changed
+  expect_identical(result$schema, compiler$schema)
+  expect_identical(result$mask, compiler$mask)
+})

--- a/tests/testthat/test-project-rel.R
+++ b/tests/testthat/test-project-rel.R
@@ -1,0 +1,61 @@
+
+test_that("substrait_project() can select all columns unchanged", {
+  tbl <- data.frame(col1 = 1, col2 = "one")
+  compiler <- substrait_compiler(tbl)
+
+  result <- substrait_project(compiler, col1, col2)
+
+  expect_s3_class(result, "SubstraitCompiler")
+
+  # check that we did append a ProjectRel
+  expect_identical(
+    result$rel$project$input,
+    compiler$rel
+  )
+
+  # check that nothing else about the compiler changed
+  expect_identical(result$schema, compiler$schema)
+  expect_identical(result$mask, compiler$mask)
+})
+
+test_that("simple_integer_field_reference() returns the correct structure", {
+  object <- simple_integer_field_reference(32)
+  expect_identical(
+    object[["selection"]][["direct_reference"]][["struct_field"]][["field"]],
+    32L
+  )
+})
+
+test_that("substrait_project() resets the mask and schema after evaluation", {
+  projected <- substrait_project(
+    data.frame(a = 1, b = 2L),
+    b
+  )
+
+  expect_identical(
+    projected$mask,
+    list(b = simple_integer_field_reference(0))
+  )
+
+  expect_identical(projected$schema$names, "b")
+  expect_identical(
+    projected$schema$struct_$types,
+    list(substrait_i32())
+  )
+})
+
+test_that("substrait_project() evaluates arguments in order", {
+  projected <- substrait_project(
+    data.frame(a = 1),
+    b = a,
+    c = b
+  )
+
+  expect_identical(
+    projected$mask,
+    list(
+      b = simple_integer_field_reference(0),
+      c = simple_integer_field_reference(1)
+    )
+  )
+})

--- a/tests/testthat/test-sort-rel.R
+++ b/tests/testthat/test-sort-rel.R
@@ -1,0 +1,48 @@
+
+test_that("substrait_sort() appends a SortRel to a compiler", {
+  tbl <- data.frame(col1 = 1, col2 = "one")
+  compiler <- substrait_compiler(tbl)
+
+  result <- substrait_sort(compiler)
+
+  expect_s3_class(result, "SubstraitCompiler")
+
+  # check that we did append a SortRel
+  expect_identical(
+    result$rel$sort$input,
+    compiler$rel
+  )
+
+  # check that the sorts list is empty
+  expect_length(
+    result$rel$sort$sorts,
+    0
+  )
+
+  # check that nothing else about the compiler changed
+  expect_identical(result$schema, compiler$schema)
+  expect_identical(result$mask, compiler$mask)
+})
+
+test_that("substrait_sort() expressions can contain substrait_sort_field()", {
+  result <- substrait_sort(
+    data.frame(a = 1, b = "one"),
+    substrait_sort_field(a, "SORT_DIRECTION_DESC_NULLS_LAST")
+  )
+
+  expect_identical(
+    result$rel$sort$sorts[[1]]$direction,
+    unclass(substrait$SortField$SortDirection$SORT_DIRECTION_DESC_NULLS_LAST)
+  )
+
+  # check with substrait:: prefix too
+  result <- substrait_sort(
+    data.frame(a = 1, b = "one"),
+    substrait::substrait_sort_field(a, "SORT_DIRECTION_DESC_NULLS_LAST")
+  )
+
+  expect_identical(
+    result$rel$sort$sorts[[1]]$direction,
+    unclass(substrait$SortField$SortDirection$SORT_DIRECTION_DESC_NULLS_LAST)
+  )
+})


### PR DESCRIPTION
In Substrait, field references refer to those of the input relation and not to the initial `ReadRel`! Previously this did not work:

``` r
library(substrait, warn.conflicts = FALSE)
library(dplyr, warn.conflicts = FALSE)

data.frame(a = 1, b = 2) %>%
  duckdb_substrait_compiler() %>%
  select(b) %>%
  filter(b > 100) %>%
  collect()
#> Error in as_substrait.substrait_Expression(X[[i]], ...): Field reference out of bounds [1]
```

After this PR:

``` r
library(substrait, warn.conflicts = FALSE)
library(dplyr, warn.conflicts = FALSE)

data.frame(a = 1, b = 2) %>%
  duckdb_substrait_compiler() %>%
  select(b) %>%
  filter(b > 100) %>%
  collect()
#> # A tibble: 0 × 1
#> # … with 1 variable: b <dbl>
```

This PR also updates the evaluation so that it does it "in order", meaning you can access previous arguments by name like in `transmute()`, `mutate()`, `tibble()`, etc.

Fixes #121:

``` r
library(substrait, warn.conflicts = FALSE)
library(dplyr, warn.conflicts = FALSE)

mtcars %>%
  duckdb_substrait_compiler() %>%
  select(hp) %>%
  filter(hp > 100) %>%
  collect()
#> # A tibble: 23 × 1
#>       hp
#>    <dbl>
#>  1   110
#>  2   110
#>  3   110
#>  4   175
#>  5   105
#>  6   245
#>  7   123
#>  8   123
#>  9   180
#> 10   180
#> # … with 13 more rows
```

<sup>Created on 2022-05-30 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Fixes #55:

``` r
library(arrow, warn.conflicts = FALSE)
library(dplyr, warn.conflicts = FALSE)
library(substrait, warn.conflicts = FALSE)
mtcars %>%
  arrow_substrait_compiler() %>%
  select(mpg, wt) %>%
  mutate(mp2 = mpg + 2) %>% 
  collect()
#> # A tibble: 32 × 3
#>      mpg    wt   mp2
#>    <dbl> <dbl> <dbl>
#>  1  21    2.62  23  
#>  2  21    2.88  23  
#>  3  22.8  2.32  24.8
#>  4  21.4  3.22  23.4
#>  5  18.7  3.44  20.7
#>  6  18.1  3.46  20.1
#>  7  14.3  3.57  16.3
#>  8  24.4  3.19  26.4
#>  9  22.8  3.15  24.8
#> 10  19.2  3.44  21.2
#> # … with 22 more rows
```

<sup>Created on 2022-05-30 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Fixes #59:

``` r
library(arrow, warn.conflicts = FALSE)
library(dplyr, warn.conflicts = FALSE)
library(substrait)
#> 
#> Attaching package: 'substrait'
#> The following object is masked from 'package:stats':
#> 
#>     filter

mtcars %>%
  arrow_substrait_compiler() %>% 
  transmute(hp, hp2 = hp + 2, hp2 = hp2 + 3) %>% 
  collect() %>% 
  head()
#> # A tibble: 6 × 2
#>      hp   hp2
#>   <dbl> <dbl>
#> 1   110   115
#> 2   110   115
#> 3    93    98
#> 4   110   115
#> 5   175   180
#> 6   105   110
```

<sup>Created on 2022-05-30 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Fixes #54:

``` r
library(arrow, warn.conflicts = FALSE)
library(substrait)
library(dplyr, warn.conflicts = FALSE)

mtcars %>%
  arrow_substrait_compiler() %>%
  mutate(hp = hp + 1) %>%
  collect()
#> # A tibble: 32 × 11
#>      mpg   cyl  disp    hp  drat    wt  qsec    vs    am  gear  carb
#>    <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
#>  1  21       6  160    111  3.9   2.62  16.5     0     1     4     4
#>  2  21       6  160    111  3.9   2.88  17.0     0     1     4     4
#>  3  22.8     4  108     94  3.85  2.32  18.6     1     1     4     1
#>  4  21.4     6  258    111  3.08  3.22  19.4     1     0     3     1
#>  5  18.7     8  360    176  3.15  3.44  17.0     0     0     3     2
#>  6  18.1     6  225    106  2.76  3.46  20.2     1     0     3     1
#>  7  14.3     8  360    246  3.21  3.57  15.8     0     0     3     4
#>  8  24.4     4  147.    63  3.69  3.19  20       1     0     4     2
#>  9  22.8     4  141.    96  3.92  3.15  22.9     1     0     4     2
#> 10  19.2     6  168.   124  3.92  3.44  18.3     1     0     4     4
#> # … with 22 more rows
```

<sup>Created on 2022-05-30 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

