### PR TITLE
Unskip tests after #97 closed

### DIFF
--- a/tests/testthat/test-arrow-dplyr-filter.R
+++ b/tests/testthat/test-arrow-dplyr-filter.R
@@ -150,7 +150,7 @@ test_that("filtering with expression + autocasting", {
 
 test_that("More complex select/filter", {
   # skip("== not yet implemented: https://github.com/voltrondata/substrait-r/issues/92")
-  skip("https://github.com/voltrondata/substrait-r/issues/97")
+  skip("Multiple filter conditions: https://github.com/voltrondata/substrait-r/issues/139")
   compare_dplyr_binding(
     engine = "duckdb",
     .input %>%

--- a/tests/testthat/test-arrow-dplyr-select.R
+++ b/tests/testthat/test-arrow-dplyr-select.R
@@ -98,7 +98,6 @@ test_that("filtering with rename", {
     example_data
   )
 
-  skip("https://github.com/voltrondata/substrait-r/issues/97")
   compare_dplyr_binding(
     engine = "duckdb",
     .input %>%


### PR DESCRIPTION
There was a test which was previously skipped due to calling select() after filter() not working - one has been unskipped and one reskipped due to multiple filter conditions causing an error - see #139 