### PR TITLE
Restore missing groups in a group_by which aren't included in a subsequent select()

### DIFF
--- a/R/pkg-dplyr.R
+++ b/R/pkg-dplyr.R
@@ -35,6 +35,26 @@ select.SubstraitCompiler <- function(.data, ...) {
     from_substrait(.data$schema, data.frame())
   )
 
+  # restore groups
+  if (!rlang::is_empty(.data$groups)) {
+
+    prepend_cols <- tidyselect::eval_select(
+      rlang::expr(names(.data$groups)),
+      from_substrait(.data$schema, data.frame())
+    )
+
+    column_indices <- c(prepend_cols, column_indices)
+
+    cat(
+      paste(
+        "Adding missing grouping variables:",
+        paste0("`", names(prepend_cols), "`", collapse = ", ")
+      ),
+      fill = TRUE
+    )
+
+  }
+
   new_mask <- rlang::set_names(
     rlang::syms(.data$schema$names[column_indices]),
     names(column_indices)

--- a/tests/testthat/test-dplyr-select.R
+++ b/tests/testthat/test-dplyr-select.R
@@ -12,7 +12,6 @@ test_that("Empty select returns no columns", {
 })
 
 test_that("Empty select still includes the group_by columns", {
-  skip("add back in missing col: https://github.com/voltrondata/substrait-r/issues/136")
 
   expect_message(
     compare_dplyr_binding(


### PR DESCRIPTION
Fixes #136 