### PR TITLE
Support .env in expressions

### DIFF
--- a/R/expression.R
+++ b/R/expression.R
@@ -73,9 +73,12 @@ substrait_eval_expr <- function(x, compiler, env, template) {
   if (rlang::is_call(x, c("$", "[["))) {
     if (rlang::is_symbol(x[[2]], ".data") && rlang::is_symbol(x[[1]], c("$", "[["))) {
       return(rlang::eval_tidy(x, compiler$mask, env))
-    } else if (rlang::is_symbol(x[[2]], ".env") && rlang::is_symbol(x[[1]], c("$", "[["))) {
-      x[[2]] <- env
-      return(rlang::eval_tidy(x, compiler$mask, env))
+    } else if (rlang::is_symbol(x[[2]], ".env") && rlang::is_symbol(x[[1]], "$")) {
+      key <- as.character(x[[3]])
+      return(get(key, envir = env, inherits = TRUE))
+    } else if (rlang::is_symbol(x[[2]], ".env") && rlang::is_symbol(x[[1]], "[[")) {
+      key <- as.character(rlang::eval_tidy(x[[3]], env = env))
+      return(get(key, envir = env, inherits = TRUE))
     }
   }
 

--- a/R/expression.R
+++ b/R/expression.R
@@ -68,8 +68,13 @@ as_substrait.quosure <- function(x, .ptype = NULL, ...,
 }
 
 substrait_eval_expr <- function(x, compiler, env, template) {
+  # Handle .data and .env pronouns that are also supported in dplyr's
+  # tidy evaluation.
   if (rlang::is_call(x, c("$", "[["))) {
     if (rlang::is_symbol(x[[2]], ".data") && rlang::is_symbol(x[[1]], c("$", "[["))) {
+      return(rlang::eval_tidy(x, compiler$mask, env))
+    } else if (rlang::is_symbol(x[[2]], ".env") && rlang::is_symbol(x[[1]], c("$", "[["))) {
+      x[[2]] <- env
       return(rlang::eval_tidy(x, compiler$mask, env))
     }
   }

--- a/tests/testthat/test-dplyr-filter.R
+++ b/tests/testthat/test-dplyr-filter.R
@@ -431,4 +431,13 @@ test_that("filter() with .data pronoun", {
     example_data
   )
 
+  compare_dplyr_binding(
+    #skip("arithmetic functions not yet implemented: https://github.com/voltrondata/substrait-r/issues/20")
+    engine = "duckdb",
+    .input %>%
+      filter(.data$dbl < .env[["chr"]]) %>%
+      select(.data$chr, .data$int, .data$lgl) %>%
+      collect(),
+    example_data
+  )
 })

--- a/tests/testthat/test-dplyr-filter.R
+++ b/tests/testthat/test-dplyr-filter.R
@@ -425,7 +425,7 @@ test_that("filter() with .data pronoun", {
     #skip("arithmetic functions not yet implemented: https://github.com/voltrondata/substrait-r/issues/20")
     engine = "duckdb",
     .input %>%
-      filter(.data$dbl < !!chr) %>%
+      filter(.data$dbl < .env$chr) %>%
       select(.data$chr, .data$int, .data$lgl) %>%
       collect(),
     example_data

--- a/tests/testthat/test-expression.R
+++ b/tests/testthat/test-expression.R
@@ -37,6 +37,19 @@ test_that("quosures with field references can be translated to Expressions", {
   expect_identical(as_substrait(rlang::quo(.data[["b"]]), compiler = compiler), ref_b)
 })
 
+test_that("quosures with the .env pronoun can be translated to Expressions", {
+  some_variable_in_env <- 5
+  expect_identical(
+    as_substrait(rlang::quo(.env$some_variable_in_env)),
+    as_substrait(5, "substrait.Expression")
+  )
+
+  expect_identical(
+    as_substrait(rlang::quo(.env[["some_variable_in_env"]])),
+    as_substrait(5, "substrait.Expression")
+  )
+})
+
 test_that("quosures with calls can be translated to Expressions", {
   compiler <- substrait_compiler(data.frame(a = double(), b = character()))
 

--- a/tests/testthat/test-expression.R
+++ b/tests/testthat/test-expression.R
@@ -48,6 +48,12 @@ test_that("quosures with the .env pronoun can be translated to Expressions", {
     as_substrait(rlang::quo(.env[["some_variable_in_env"]])),
     as_substrait(5, "substrait.Expression")
   )
+
+  key <- "some_variable_in_env"
+  expect_identical(
+    as_substrait(rlang::quo(.env[[key]])),
+    as_substrait(5, "substrait.Expression")
+  )
 })
 
 test_that("quosures with calls can be translated to Expressions", {


### PR DESCRIPTION
Fixes #104:

``` r
library(substrait, warn.conflicts = FALSE)
library(dplyr, warn.conflicts = FALSE)

hp_val <- 110

mtcars %>%
  filter(.data$hp == .env$hp_val) %>%
  collect()
#>                 mpg cyl disp  hp drat    wt  qsec vs am gear carb
#> Mazda RX4      21.0   6  160 110 3.90 2.620 16.46  0  1    4    4
#> Mazda RX4 Wag  21.0   6  160 110 3.90 2.875 17.02  0  1    4    4
#> Hornet 4 Drive 21.4   6  258 110 3.08 3.215 19.44  1  0    3    1
```

<sup>Created on 2022-07-08 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>