### PR TITLE
Update test skip reason

### DIFF
--- a/tests/testthat/test-dplyr-summarise.R
+++ b/tests/testthat/test-dplyr-summarise.R
@@ -23,7 +23,7 @@ test_that("Can aggregate", {
     example_data
   )
 
-  skip("https://github.com/voltrondata/substrait-r/issues/142")
+  skip("https://github.com/voltrondata/substrait-r/issues/215")
 
   compare_dplyr_binding(
     engine = "duckdb",


### PR DESCRIPTION
Original reason for test skip now changed to the fact that a parameter isn't implemented rather than other issues with summarise()