### PR TITLE
Implement n() binding in DuckDB function bindings

### DIFF
--- a/R/pkg-duckdb.R
+++ b/R/pkg-duckdb.R
@@ -303,3 +303,7 @@ duckdb_funs[["^"]] <- function(lhs, rhs) {
 duckdb_funs[["sum"]] <- function(x) {
   substrait_call_agg("sum", x, .output_type = identity)
 }
+
+duckdb_funs[["n"]] <- function() {
+  substrait_call_agg("count", .output_type = substrait_i64())
+}

--- a/tests/testthat/test-pkg-duckdb.R
+++ b/tests/testthat/test-pkg-duckdb.R
@@ -246,6 +246,6 @@ test_that("duckdb translation for n() works", {
       dplyr::group_by(lgl) %>%
       dplyr::summarise(n = n()) %>%
       dplyr::collect(),
-    tibble::tibble(lgl = c(NA, TRUE, FALSE), `n` = c(3L,4L,3L))
+    tibble::tibble(lgl = c(NA, TRUE, FALSE), n = c(3L, 4L, 3L))
   )
 })

--- a/tests/testthat/test-pkg-duckdb.R
+++ b/tests/testthat/test-pkg-duckdb.R
@@ -236,3 +236,16 @@ test_that("duckdb raises error for empty projection", {
     "Column list must not be empty"
   )
 })
+
+test_that("duckdb translation for n() works", {
+  skip_if_not(has_duckdb_with_substrait())
+
+  expect_identical(
+    example_data %>%
+      duckdb_substrait_compiler() %>%
+      dplyr::group_by(lgl) %>%
+      dplyr::summarise(n = n()) %>%
+      dplyr::collect(),
+    tibble::tibble(lgl = c(NA, TRUE, FALSE), `n` = c(3L,4L,3L))
+  )
+})


### PR DESCRIPTION
Fixes #143 

I'd initially intended to complete bindings for Arrow here, but that isn't yet supported in Acero and so have deferred it to #219 