### PR TITLE
Implement n() in Arrow bindings

### DIFF
--- a/R/compiler.R
+++ b/R/compiler.R
@@ -422,22 +422,10 @@ substrait_call <- function(.fun, ..., .output_type = NULL, .options = NULL) {
 
 #' @rdname substrait_call
 #' @export
-substrait_call_agg <- function(.fun, ..., .output_type = NULL) {
+substrait_call_agg <- function(.fun, ..., .output_type = NULL, phase = 0L, invocation = 0L) {
   args <- rlang::list2(...)
   compiler <- current_compiler()
-  template <- substrait$AggregateFunction$create()
-  compiler$resolve_function(.fun, args, template, .output_type)
-}
-
-#' @rdname substrait_call
-#'
-#' Temporary function allowing compatibility with Arrow until more options supported
-#'
-#' @export
-substrait_call_agg_temp <- function(.fun, ..., .output_type = NULL) {
-  args <- rlang::list2(...)
-  compiler <- current_compiler()
-  template <- substrait$AggregateFunction$create(phase = 3L, invocation = 1L)
+  template <- substrait$AggregateFunction$create(phase = phase, invocation = invocation)
   compiler$resolve_function(.fun, args, template, .output_type)
 }
 

--- a/R/compiler.R
+++ b/R/compiler.R
@@ -430,6 +430,18 @@ substrait_call_agg <- function(.fun, ..., .output_type = NULL) {
 }
 
 #' @rdname substrait_call
+#'
+#' Temporary function allowing compatibility with Arrow until more options supported
+#'
+#' @export
+substrait_call_agg_temp <- function(.fun, ..., .output_type = NULL) {
+  args <- rlang::list2(...)
+  compiler <- current_compiler()
+  template <- substrait$AggregateFunction$create(phase = 3L, invocation = 1L)
+  compiler$resolve_function(.fun, args, template, .output_type)
+}
+
+#' @rdname substrait_call
 #' @export
 substrait_eval <- function(expr) {
   substrait_eval_quo(rlang::enquo(expr), .data = FALSE)

--- a/R/pkg-arrow.R
+++ b/R/pkg-arrow.R
@@ -76,7 +76,7 @@ arrow_funs[[">"]] <- function(lhs, rhs) {
 }
 
 # TODO: remove `x` input parameter as this should not be needed for `count` function
-# TODO: remove non-default phase/invocation values
+# TODO: remove non-default phase/invocation values when these supported in Arrow
 arrow_funs[["n"]] <- function(x) {
   substrait_call_agg(
     "aggregate_generic.count",

--- a/R/pkg-arrow.R
+++ b/R/pkg-arrow.R
@@ -75,6 +75,15 @@ arrow_funs[[">"]] <- function(lhs, rhs) {
   )
 }
 
+# TODO: remove `x` input parameter as this should not be needed for `count` function
+arrow_funs[["n"]] <- function(x) {
+  substrait_call_agg_temp(
+    "aggregate_generic.count",
+    x,
+    .output_type = substrait_i64()
+  )
+}
+
 #' Create an Arrow Substrait Compiler
 #'
 #' @param object A [data.frame()], [arrow::Table], [arrow::RecordBatch],

--- a/R/pkg-arrow.R
+++ b/R/pkg-arrow.R
@@ -76,11 +76,14 @@ arrow_funs[[">"]] <- function(lhs, rhs) {
 }
 
 # TODO: remove `x` input parameter as this should not be needed for `count` function
+# TODO: remove non-default phase/invocation values
 arrow_funs[["n"]] <- function(x) {
-  substrait_call_agg_temp(
+  substrait_call_agg(
     "aggregate_generic.count",
     x,
-    .output_type = substrait_i64()
+    .output_type = substrait_i64(),
+    phase = 3L,
+    invocation = 1L
   )
 }
 

--- a/tests/testthat/test-pkg-arrow.R
+++ b/tests/testthat/test-pkg-arrow.R
@@ -297,3 +297,16 @@ test_that("substrait_eval_arrow() can evaluate a plan with one read relation", {
     error = TRUE
   )
 })
+
+test_that("arrow translation for n() works", {
+  skip_if_not(has_arrow_with_substrait())
+
+  expect_identical(
+    example_data %>%
+      arrow_substrait_compiler() %>%
+      dplyr::group_by(lgl) %>%
+      dplyr::summarise(n = n()) %>%
+      dplyr::collect(),
+    tibble::tibble(lgl = c(NA, TRUE, FALSE), n = c(3L, 4L, 3L))
+  )
+})


### PR DESCRIPTION
Fixes #219.  However, this is not mergable yet due to what I think is a bug in the Arrow consumer.  I have opened [ARROW-18403](https://issues.apache.org/jira/browse/ARROW-18403) to report this.

```
library(arrow)
library(substrait)
library(dplyr)

data = tibble::tibble(
  x = 1:10,
  grp = c(rep(c("a", "b"), each = 4), NA, NA)
)

data
#> # A tibble: 10 × 2
#>        x grp  
#>    <int> <chr>
#>  1     1 a    
#>  2     2 a    
#>  3     3 a    
#>  4     4 a    
#>  5     5 b    
#>  6     6 b    
#>  7     7 b    
#>  8     8 b    
#>  9     9 <NA> 
#> 10    10 <NA>

data %>%
  arrow_substrait_compiler() %>%
  group_by(grp) %>%
  summarise(total_group_members = n(x)) %>%
  collect()
#> # A tibble: 3 × 2
#>     grp total_group_members
#>   <int> <chr>              
#> 1     4 a                  
#> 2     4 b                  
#> 3     2 <NA>

data %>%
  arrow_substrait_compiler() %>%
  group_by(grp) %>%
  summarise(total_group_members = n(grp)) %>%
  collect()
#> # A tibble: 3 × 2
#>     grp total_group_members
#>   <int> <chr>              
#> 1     4 a                  
#> 2     4 b                  
#> 3     0 <NA>

data %>%
  arrow_substrait_compiler() %>%
  summarise(total_group_members = n(x)) %>%
  collect()
#> # A tibble: 1 × 1
#>   total_group_members
#>                 <int>
#> 1                  10

data %>%
  arrow_substrait_compiler() %>%
  summarise(total_group_members = n(grp)) %>%
  collect()
#> # A tibble: 1 × 1
#>   total_group_members
#>                 <int>
#> 1                   8
```