### PR TITLE
MINOR: update arrow substrait flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ remotes::install_github("voltrondata/substrait-r")
 You will need a [development version of the arrow
 package](https://arrow.apache.org/docs/r/articles/developers/setup.html)
 to actually evaluate anything (in particular, with Arrow configured
-using `-DARROW_ENGINE=ON`).
+using `-DARROW_SUBSTRAIT=ON`).
 
 ## Example
 


### PR DESCRIPTION
The `README.md` file mentions using the flag `-DARROW_ENGINE=ON`, but "ARROW_ENGINE" has been renamed to "ARROW_SUBSTRAIT" ([ARROW-16158](https://issues.apache.org/jira/browse/ARROW-16158))