### PR TITLE
Add translations for Arrow arithmetic functions

### DIFF
--- a/R/pkg-arrow.R
+++ b/R/pkg-arrow.R
@@ -66,6 +66,107 @@ arrow_funs[["+"]] <- function(lhs, rhs) {
   )
 }
 
+arrow_funs[["-"]] <- function(lhs, rhs) {
+  substrait_call(
+    "arithmetic.subtract",
+    lhs,
+    rhs,
+    .output_type = substrait_fp64(),
+    .options = list(
+      substrait$FunctionOption$create(
+        name = "overflow",
+        preference = "ERROR"
+      )
+    )
+  )
+}
+
+arrow_funs[["*"]] <- function(lhs, rhs) {
+  substrait_call(
+    "arithmetic.multiply",
+    lhs,
+    rhs,
+    .output_type = substrait_fp64(),
+    .options = list(
+      substrait$FunctionOption$create(
+        name = "overflow",
+        preference = "ERROR"
+      )
+    )
+  )
+}
+
+arrow_funs[["/"]] <- function(lhs, rhs) {
+  substrait_call(
+    "arithmetic.divide",
+    lhs,
+    rhs,
+    .output_type = substrait_fp64(),
+    .options = list(
+      substrait$FunctionOption$create(
+        name = "overflow",
+        preference = "ERROR"
+      )
+    )
+  )
+}
+
+arrow_funs[["sqrt"]] <- function(x) {
+  substrait_call(
+    "arithmetic.sqrt",
+    x,
+    .output_type = substrait_fp64(),
+    .options = list(
+      substrait$FunctionOption$create(
+        name = "overflow",
+        preference = "ERROR"
+      )
+    )
+  )
+}
+
+arrow_funs[["abs"]] <- function(x) {
+  substrait_call(
+    "arithmetic.abs",
+    x,
+    .output_type = function(x) x,
+    .options = list(
+      substrait$FunctionOption$create(
+        name = "overflow",
+        preference = "ERROR"
+      )
+    )
+  )
+}
+
+arrow_funs[["exp"]] <- function(x) {
+  substrait_call(
+    "arithmetic.exp",
+    x,
+    .output_type = substrait_fp64(),
+    .options = list(
+      substrait$FunctionOption$create(
+        name = "overflow",
+        preference = "ERROR"
+      )
+    )
+  )
+}
+
+arrow_funs[["sign"]] <- function(x) {
+  substrait_call(
+    "arithmetic.sign",
+    x,
+    .output_type = substrait_fp64(),
+    .options = list(
+      substrait$FunctionOption$create(
+        name = "overflow",
+        preference = "ERROR"
+      )
+    )
+  )
+}
+
 # TODO: remove non-default `.phase` and `.invocation` param values for aggregation functions when Arrow consumer supports this
 
 arrow_funs[["sum"]] <- function(x, na.rm = FALSE) {

--- a/R/pkg-arrow.R
+++ b/R/pkg-arrow.R
@@ -60,7 +60,7 @@ arrow_funs[["+"]] <- function(lhs, rhs) {
     .options = list(
       substrait$FunctionOption$create(
         name = "overflow",
-        preference = "ERROR"
+        preference = "SILENT"
       )
     )
   )
@@ -75,7 +75,7 @@ arrow_funs[["-"]] <- function(lhs, rhs) {
     .options = list(
       substrait$FunctionOption$create(
         name = "overflow",
-        preference = "ERROR"
+        preference = "SILENT"
       )
     )
   )
@@ -90,7 +90,7 @@ arrow_funs[["*"]] <- function(lhs, rhs) {
     .options = list(
       substrait$FunctionOption$create(
         name = "overflow",
-        preference = "ERROR"
+        preference = "SILENT"
       )
     )
   )
@@ -105,7 +105,7 @@ arrow_funs[["/"]] <- function(lhs, rhs) {
     .options = list(
       substrait$FunctionOption$create(
         name = "overflow",
-        preference = "ERROR"
+        preference = "SILENT"
       )
     )
   )
@@ -119,7 +119,7 @@ arrow_funs[["sqrt"]] <- function(x) {
     .options = list(
       substrait$FunctionOption$create(
         name = "overflow",
-        preference = "ERROR"
+        preference = "SILENT"
       )
     )
   )
@@ -133,7 +133,7 @@ arrow_funs[["abs"]] <- function(x) {
     .options = list(
       substrait$FunctionOption$create(
         name = "overflow",
-        preference = "ERROR"
+        preference = "SILENT"
       )
     )
   )
@@ -147,7 +147,7 @@ arrow_funs[["exp"]] <- function(x) {
     .options = list(
       substrait$FunctionOption$create(
         name = "overflow",
-        preference = "ERROR"
+        preference = "SILENT"
       )
     )
   )
@@ -161,7 +161,7 @@ arrow_funs[["sign"]] <- function(x) {
     .options = list(
       substrait$FunctionOption$create(
         name = "overflow",
-        preference = "ERROR"
+        preference = "SILENT"
       )
     )
   )

--- a/R/pkg-arrow.R
+++ b/R/pkg-arrow.R
@@ -111,6 +111,21 @@ arrow_funs[["/"]] <- function(lhs, rhs) {
   )
 }
 
+arrow_funs[["^"]] <- function(lhs, rhs) {
+  substrait_call(
+    "arithmetic.power",
+    lhs,
+    rhs,
+    .output_type = substrait_fp64(),
+    .options = list(
+      substrait$FunctionOption$create(
+        name = "overflow",
+        preference = "SILENT"
+      )
+    )
+  )
+}
+
 arrow_funs[["sqrt"]] <- function(x) {
   substrait_call(
     "arithmetic.sqrt",

--- a/tests/testthat/test-dplyr-filter.R
+++ b/tests/testthat/test-dplyr-filter.R
@@ -39,8 +39,6 @@ test_that("Filter should be able to return an empty table", {
 test_that("filtering with expression", {
   char_sym <- "b"
   compare_dplyr_binding(
-    # skip("== not implemented yet: https://github.com/voltrondata/substrait-r/issues/92")
-    engine = "duckdb",
     .input %>%
       filter(chr == char_sym) %>%
       select(string = chr, int) %>%
@@ -260,8 +258,6 @@ test_that("filter environment scope", {
 
   b_var <- "b"
   compare_dplyr_binding(
-    #   skip("== not yet implemented: https://github.com/voltrondata/substrait-r/issues/92")
-    engine = "duckdb",
     .input %>%
       filter(chr == b_var) %>%
       collect(),
@@ -274,7 +270,6 @@ test_that("filter environment scope", {
     example_data
   )
 
-  skip("== not defined (Arrow) https://github.com/voltrondata/substrait-r/issues/76")
   # This works but only because there are S3 methods for those operations
   skip("user-defined functions not supported https://github.com/voltrondata/substrait-r/issues/102")
   isEqualTo <- function(x, y) x == y & !is.na(x)

--- a/tests/testthat/test-dplyr-filter.R
+++ b/tests/testthat/test-dplyr-filter.R
@@ -59,7 +59,6 @@ test_that("filtering with arithmetic", {
   )
 
   compare_dplyr_binding(
-    engine = "duckdb",
     .input %>%
       filter(some_negative / 2 > 3) %>%
       select(string = chr, int, dbl) %>%
@@ -68,7 +67,6 @@ test_that("filtering with arithmetic", {
   )
 
   compare_dplyr_binding(
-    engine = "duckdb",
     .input %>%
       filter(some_negative / 2L > 3) %>%
       select(string = chr, int, dbl) %>%
@@ -77,7 +75,6 @@ test_that("filtering with arithmetic", {
   )
 
   compare_dplyr_binding(
-    engine = "duckdb",
     .input %>%
       filter(some_negative / 2 > 3) %>%
       select(string = chr, int, dbl) %>%
@@ -86,7 +83,6 @@ test_that("filtering with arithmetic", {
   )
 
   compare_dplyr_binding(
-    engine = "duckdb",
     .input %>%
       filter(some_negative / 2L > 3) %>%
       select(string = chr, int, dbl) %>%
@@ -105,7 +101,6 @@ test_that("filtering with arithmetic", {
   )
 
   compare_dplyr_binding(
-    engine = "duckdb",
     .input %>%
       filter(int^2 > 3) %>%
       select(string = chr, int, dbl) %>%
@@ -116,8 +111,6 @@ test_that("filtering with arithmetic", {
 
 test_that("filtering with expression + autocasting", {
   compare_dplyr_binding(
-    # skip("arithmetic functions not yet implemented: https://github.com/voltrondata/substrait-r/issues/20")
-    engine = "duckdb",
     .input %>%
       filter(some_negative + 1 > 3L) %>% # test autocasting with comparison to 3L
       select(string = chr, int, dbl) %>%
@@ -126,7 +119,6 @@ test_that("filtering with expression + autocasting", {
   )
 
   compare_dplyr_binding(
-    engine = "duckdb",
     .input %>%
       filter(int + 1 > 3) %>%
       select(string = chr, int, dbl) %>%
@@ -135,7 +127,6 @@ test_that("filtering with expression + autocasting", {
   )
 
   compare_dplyr_binding(
-    engine = "duckdb",
     .input %>%
       filter(int^2 > 3) %>%
       select(string = chr, int, dbl) %>%

--- a/tests/testthat/test-dplyr-group_by.R
+++ b/tests/testthat/test-dplyr-group_by.R
@@ -20,8 +20,7 @@ test_that("group_by groupings are recorded", {
     .input %>%
       group_by(chr) %>%
       select(int, chr) %>%
-      # skip("comparison operators not implemented yet: https://github.com/voltrondata/substrait-r/issues/92")
-      # filter(int > 5) %>%
+      filter(int > 5) %>%
       collect(),
     example_data
   )
@@ -37,7 +36,6 @@ test_that("group_by supports creating/renaming", {
   )
 
   compare_dplyr_binding(
-    engine = "duckdb",
     .input %>%
       group_by(chr, numbers = int * 4) %>%
       collect(),
@@ -45,7 +43,6 @@ test_that("group_by supports creating/renaming", {
   )
 
   compare_dplyr_binding(
-    engine = "duckdb",
     .input %>%
       group_by(int > 4, lgl, foo = int > 5) %>%
       collect(),
@@ -59,8 +56,7 @@ test_that("ungroup", {
       group_by(chr) %>%
       select(int, chr) %>%
       ungroup() %>%
-      # skip("comparison operators not implemented yet: https://github.com/voltrondata/substrait-r/issues/92")
-      # filter(int > 5) %>%
+      filter(int > 5) %>%
       collect(),
     example_data
   )

--- a/tests/testthat/test-dplyr-select.R
+++ b/tests/testthat/test-dplyr-select.R
@@ -89,7 +89,6 @@ test_that("select using selection helpers", {
 
 test_that("filtering with rename", {
 
-  # skip("https://github.com/voltrondata/substrait-r/issues/92")
   compare_dplyr_binding(
     engine = "duckdb",
     .input %>%

--- a/tests/testthat/test-pkg-arrow.R
+++ b/tests/testthat/test-pkg-arrow.R
@@ -418,6 +418,18 @@ test_that("arrow translation for / works", {
   )
 })
 
+test_that("arrow translation for ^ works", {
+  skip_if_not(has_arrow_with_substrait())
+
+  expect_equal(
+    example_data[1:5, "dbl"] %>%
+      arrow_substrait_compiler() %>%
+      substrait_project(dbl = dbl ^ 3) %>%
+      dplyr::collect(),
+    tibble::tibble(dbl = c(-997002999, -970299, -729, 0, 729))
+  )
+})
+
 test_that("arrow translation for sqrt() works", {
   skip_if_not(has_arrow_with_substrait())
 

--- a/tests/testthat/test-pkg-arrow.R
+++ b/tests/testthat/test-pkg-arrow.R
@@ -369,3 +369,102 @@ test_that("arrow translation for >= works", {
     tibble::tibble(dbl = c(0, 9))
   )
 })
+
+test_that("arrow translation for + works", {
+  skip_if_not(has_arrow_with_substrait())
+
+  expect_equal(
+    example_data[1:5, "dbl"] %>%
+      arrow_substrait_compiler() %>%
+      substrait_project(dbl = dbl + 3) %>%
+      dplyr::collect(),
+    tibble::tibble(dbl = c(-996, -96, -6, 3, 12))
+  )
+})
+
+test_that("arrow translation for - works", {
+  skip_if_not(has_arrow_with_substrait())
+
+  expect_equal(
+    example_data[1:5, "dbl"] %>%
+      arrow_substrait_compiler() %>%
+      substrait_project(dbl = dbl - 3) %>%
+      dplyr::collect(),
+    tibble::tibble(dbl = c(-1002, -102, -12, -3, 6))
+  )
+})
+
+test_that("arrow translation for * works", {
+  skip_if_not(has_arrow_with_substrait())
+
+  expect_equal(
+    example_data[1:5, "dbl"] %>%
+      arrow_substrait_compiler() %>%
+      substrait_project(dbl = dbl * 3) %>%
+      dplyr::collect(),
+    tibble::tibble(dbl = c(-2997, -297, -27, 0, 27))
+  )
+})
+
+test_that("arrow translation for / works", {
+  skip_if_not(has_arrow_with_substrait())
+
+  expect_equal(
+    example_data[1:5, "dbl"] %>%
+      arrow_substrait_compiler() %>%
+      substrait_project(dbl = dbl / 3) %>%
+      dplyr::collect(),
+    tibble::tibble(dbl = c(-333, -33, -3, 0, 3))
+  )
+})
+
+test_that("arrow translation for sqrt() works", {
+  skip_if_not(has_arrow_with_substrait())
+
+  expect_equal(
+    example_data[1:5, "dbl"] %>%
+      arrow_substrait_compiler() %>%
+      substrait_project(dbl = sqrt(dbl)) %>%
+      dplyr::collect(),
+    tibble::tibble(dbl = c(NaN, NaN, NaN, 0, 3))
+  )
+})
+
+test_that("arrow translation for abs() works", {
+  skip_if_not(has_arrow_with_substrait())
+
+  expect_equal(
+    example_data[1:5, "dbl"] %>%
+      arrow_substrait_compiler() %>%
+      substrait_project(dbl = abs(dbl)) %>%
+      dplyr::collect(),
+    tibble::tibble(dbl = c(999, 99, 9, 0, 9))
+  )
+})
+
+test_that("arrow translation for exp() works", {
+  skip_if_not(has_arrow_with_substrait())
+
+  expect_equal(
+    example_data[1:5, "dbl"] %>%
+      arrow_substrait_compiler() %>%
+      substrait_project(dbl = exp(dbl)) %>%
+      dplyr::collect(),
+    tibble::tibble(dbl = c(
+      0, 1.01122149261045e-43, 0.00012340980408668,
+      1, 8103.08392757538
+    ))
+  )
+})
+
+test_that("arrow translation for sign() works", {
+  skip_if_not(has_arrow_with_substrait())
+
+  expect_equal(
+    example_data[1:5, "dbl"] %>%
+      arrow_substrait_compiler() %>%
+      substrait_project(dbl = sign(dbl)) %>%
+      dplyr::collect(),
+    tibble::tibble(dbl = c(-1, -1, -1, 0, 1))
+  )
+})


### PR DESCRIPTION
This PR adds translations (or tests when there were none before) for the following arithmetic functions in Arrow:
* `+`
* `-`
* `*`
* `/`
* `^`
* `sqrt()`
* `abs()`
* `exp()`
* `sign()`

Closes #237