### PR TITLE
Implement if_else

### DIFF
--- a/R/compiler.R
+++ b/R/compiler.R
@@ -578,6 +578,21 @@ substrait_funs[["between"]] <- function(x, left, right) {
   substrait_eval(x >= left & x <= right)
 }
 
+substrait_funs[["if_else"]] <- function(condition, true, false) {
+  substrait$Expression$create(
+    if_then = substrait$Expression$IfThen$create(
+      ifs = list(
+        substrait$Expression$IfThen$IfClause$create(
+          `if` = as_substrait_expression(condition),
+          `then` = as_substrait_expression(true)
+        )
+      ),
+      `else` = as_substrait_expression(false)
+    )
+  )
+}
+
+
 substrait_expression_literal_list <- function(values) {
   substrait$Expression$create(
     literal = substrait$Expression$Literal$create(

--- a/tests/testthat/test-pkg-arrow.R
+++ b/tests/testthat/test-pkg-arrow.R
@@ -632,3 +632,18 @@ test_that("arrow translation for is.na() works", {
     )
   )
 })
+
+test_that("arrow translation for if_else() works", {
+  skip_if_not(has_arrow_with_substrait())
+
+  expect_equal(
+    example_data[1:5, "dbl"] %>%
+      arrow_substrait_compiler() %>%
+      substrait_project(dbl, gt_five = if_else(dbl > 5, "over", "under")) %>%
+      dplyr::collect(),
+    tibble::tibble(
+      dbl = c(-999, -99, -9, 0, 9),
+      gt_five = c("under", "under", "under", "under", "over")
+    )
+  )
+})

--- a/tests/testthat/test-pkg-arrow.R
+++ b/tests/testthat/test-pkg-arrow.R
@@ -637,7 +637,7 @@ test_that("arrow translation for if_else() works", {
   skip_if_not(has_arrow_with_substrait())
 
   expect_equal(
-    example_data[1:5, "dbl"] %>%
+    tibble::tibble(dbl = c(-999, -99, -9, 0, 9)) %>%
       arrow_substrait_compiler() %>%
       substrait_project(dbl, gt_five = if_else(dbl > 5, "over", "under")) %>%
       dplyr::collect(),

--- a/tests/testthat/test-pkg-duckdb.R
+++ b/tests/testthat/test-pkg-duckdb.R
@@ -309,3 +309,18 @@ test_that("duckdb translation for >= works", {
     tibble::tibble(dbl = c(0, 9))
   )
 })
+
+test_that("duckdb translation for if_else() works", {
+  skip_if_not(has_duckdb_with_substrait())
+
+  expect_equal(
+    example_data[1:5, "dbl"] %>%
+      duckdb_substrait_compiler() %>%
+      substrait_project(dbl, gt_five = if_else(dbl > 5, "over", "under")) %>%
+      dplyr::collect(),
+    tibble::tibble(
+      dbl = c(-999, -99, -9, 0, 9),
+      gt_five = c("under", "under", "under", "under", "over")
+    )
+  )
+})

--- a/tests/testthat/test-pkg-duckdb.R
+++ b/tests/testthat/test-pkg-duckdb.R
@@ -314,7 +314,7 @@ test_that("duckdb translation for if_else() works", {
   skip_if_not(has_duckdb_with_substrait())
 
   expect_equal(
-    example_data[1:5, "dbl"] %>%
+    tibble::tibble(dbl = c(-999, -99, -9, 0, 9)) %>%
       duckdb_substrait_compiler() %>%
       substrait_project(dbl, gt_five = if_else(dbl > 5, "over", "under")) %>%
       dplyr::collect(),


### PR DESCRIPTION
Fixes #156 

There is an issue with return type in DuckDB with logical values, but it won't affect the TPC-H query calculations, so I was going to leave that as something to come back to.

``` r
library(substrait)
library(dplyr)

# using Arrow
mtcars %>%
  arrow_substrait_compiler() %>%
  mutate(am_chr = if_else(am == 0, "automatic", "manual")) %>%
  select(am, am_chr) %>%
  collect()
#> # A tibble: 32 × 2
#>       am am_chr   
#>    <dbl> <chr>    
#>  1     1 manual   
#>  2     1 manual   
#>  3     1 manual   
#>  4     0 automatic
#>  5     0 automatic
#>  6     0 automatic
#>  7     0 automatic
#>  8     0 automatic
#>  9     0 automatic
#> 10     0 automatic
#> # … with 22 more rows

# using DuckDB
mtcars %>%
  duckdb_substrait_compiler() %>%
  mutate(am_chr = if_else(am == 0, "automatic", "manual")) %>%
  select(am, am_chr) %>%
  collect()
#> # A tibble: 32 × 2
#>       am am_chr   
#>    <dbl> <chr>    
#>  1     1 manual   
#>  2     1 manual   
#>  3     1 manual   
#>  4     0 automatic
#>  5     0 automatic
#>  6     0 automatic
#>  7     0 automatic
#>  8     0 automatic
#>  9     0 automatic
#> 10     0 automatic
#> # … with 22 more rows

## issue with TRUE/FALSE in DuckDB
# using Arrow
mtcars %>%
  arrow_substrait_compiler() %>%
  mutate(automatic = if_else(am == 0, TRUE, FALSE)) %>%
  select(am, automatic) %>%
  collect()
#> # A tibble: 32 × 2
#>       am automatic
#>    <dbl> <lgl>    
#>  1     1 FALSE    
#>  2     1 FALSE    
#>  3     1 FALSE    
#>  4     0 TRUE     
#>  5     0 TRUE     
#>  6     0 TRUE     
#>  7     0 TRUE     
#>  8     0 TRUE     
#>  9     0 TRUE     
#> 10     0 TRUE     
#> # … with 22 more rows

# using DuckDB
mtcars %>%
  duckdb_substrait_compiler() %>%
  mutate(automatic = if_else(am == 0, TRUE, FALSE)) %>%
  select(am, automatic) %>%
  collect()
#> # A tibble: 32 × 2
#>       am automatic
#>    <dbl>     <int>
#>  1     1         0
#>  2     1         0
#>  3     1         0
#>  4     0         1
#>  5     0         1
#>  6     0         1
#>  7     0         1
#>  8     0         1
#>  9     0         1
#> 10     0         1
#> # … with 22 more rows
```


