### PR TITLE
Implement grepl()

### DIFF
--- a/R/pkg-arrow.R
+++ b/R/pkg-arrow.R
@@ -286,7 +286,8 @@ arrow_funs[["is.na"]] <- function(x) {
   substrait_eval(!is_not_null)
 }
 
-arrow_funs[["grepl"]] <- function(pattern, x) {
+arrow_funs[["grepl"]] <- function(pattern, x, ...) {
+  rlang::check_dots_empty()
   substrait_call("string.contains", x, pattern)
 }
 

--- a/R/pkg-arrow.R
+++ b/R/pkg-arrow.R
@@ -286,6 +286,10 @@ arrow_funs[["is.na"]] <- function(x) {
   substrait_eval(!is_not_null)
 }
 
+arrow_funs[["grepl"]] <- function(pattern, x) {
+  substrait_call("string.contains", x, pattern)
+}
+
 check_na_rm <- function(na.rm) {
   if (!na.rm) {
     warning("Missing value removal from aggregate functions not yet supported, switching to na.rm = TRUE")

--- a/R/pkg-duckdb.R
+++ b/R/pkg-duckdb.R
@@ -283,6 +283,10 @@ duckdb_funs[["n"]] <- function() {
   substrait_call_agg("count", .output_type = substrait_i64())
 }
 
+duckdb_funs[["grepl"]] <- function(pattern, x) {
+  substrait_call("contains", x, pattern)
+}
+
 check_na_rm_duckdb <- function(na.rm) {
   if (!na.rm) {
     warning("Missing value removal from aggregate functions not supported in DuckDB, switching to na.rm = TRUE")

--- a/tests/testthat/test-pkg-arrow.R
+++ b/tests/testthat/test-pkg-arrow.R
@@ -632,3 +632,18 @@ test_that("arrow translation for is.na() works", {
     )
   )
 })
+
+test_that("arrow translation for grepl works", {
+  skip_if_not(has_arrow_with_substrait())
+  skip("Substrait function `contains` not yet implemented in Arrow C++")
+
+  expect_equal(
+    tibble::tibble(x = c("cat", "bat", "mouse")) %>%
+      arrow_substrait_compiler() %>%
+      substrait_filter(grepl("a", x)) %>%
+      dplyr::collect(),
+    tibble::tibble(
+      x = c("cat", "bat")
+    )
+  )
+})

--- a/tests/testthat/test-pkg-duckdb.R
+++ b/tests/testthat/test-pkg-duckdb.R
@@ -309,3 +309,18 @@ test_that("duckdb translation for >= works", {
     tibble::tibble(dbl = c(0, 9))
   )
 })
+
+test_that("duckdb translation for grepl works", {
+  skip_if_not(has_duckdb_with_substrait())
+
+  expect_equal(
+    tibble::tibble(x = c("cat", "bat", "mouse")) %>%
+      duckdb_substrait_compiler() %>%
+      substrait_filter(grepl("a", x)) %>%
+      dplyr::collect(),
+    tibble::tibble(
+      x = c("cat", "bat")
+    )
+  )
+
+})


### PR DESCRIPTION
Implements bindings for `base::grepl()`.

Works with duckdb:

```
> example_data %>%
+       duckdb_substrait_compiler() %>%
+       substrait_filter(grepl("Y ", verses)) %>%
+       dplyr::collect()
# A tibble: 3 × 9
    int   dbl  dbl2 lgl   false chr   verses                       padded_strings    some_negative
  <int> <dbl> <dbl> <lgl> <lgl> <chr> <chr>                        <chr>                     <dbl>
1     3 -9        5 NA    FALSE c     Y mil vidas malgastadas      "   c   "                    -3
2     6  3.14     5 FALSE FALSE NA    Y aunque sangro de tu herida "      f      "               6
3     7 99        5 NA    FALSE g     Y cada piedra querida        "       g       "            -7
```

Though not yet with Arrow as it's not yet implemented in Arrow's C++ bindings:

```
> example_data[, c("int", "verses")] %>%
+       arrow_substrait_compiler() %>%
+       substrait_filter(grepl("Y ", verses)) %>%
+       dplyr::collect()
Error: NotImplemented: No conversion function exists to convert the Substrait function contains to an Arrow call expression
/home/nic2/arrow/cpp/src/arrow/engine/substrait/expression_internal.cc:310  ext_set.registry()->GetSubstraitCallToArrowFallback(function_id.name)
/home/nic2/arrow/cpp/src/arrow/engine/substrait/relation_internal.cc:411  FromProto(filter.condition(), ext_set, conversion_options)
/home/nic2/arrow/cpp/src/arrow/engine/substrait/serde.cc:158  FromProto(plan_rel.has_root() ? plan_rel.root().input() : plan_rel.rel(), ext_set, conversion_options)
```