### PR TITLE
Implement binding for `n_distinct()`

### DIFF
--- a/R/pkg-arrow.R
+++ b/R/pkg-arrow.R
@@ -291,17 +291,6 @@ arrow_funs[["grepl"]] <- function(pattern, x, ...) {
   substrait_call("string.contains", x, pattern)
 }
 
-arrow_funs[["n_distinct"]] <- function(x, na.rm = FALSE) {
-  check_na_rm(na.rm)
-  substrait_call_agg(
-    "aggregate_approx.approx_count_distinct",
-    x,
-    .output_type = substrait_i64(),
-    .phase = 3L,
-    .invocation = 1L
-  )
-}
-
 check_na_rm <- function(na.rm) {
   if (!na.rm) {
     warning("Missing value removal from aggregate functions not yet supported, switching to na.rm = TRUE")

--- a/R/pkg-arrow.R
+++ b/R/pkg-arrow.R
@@ -291,9 +291,15 @@ arrow_funs[["grepl"]] <- function(pattern, x, ...) {
   substrait_call("string.contains", x, pattern)
 }
 
-arrow_funs[["n_distinct"]] <- function(..., na.rm = FALSE) {
+arrow_funs[["n_distinct"]] <- function(x, na.rm = FALSE) {
   check_na_rm(na.rm)
-  substrait_call_agg("aggregate_approx.approx_count_distinct", ..., .output_type = substrait_i64(), .phase = 3L, .invocation = 1L)
+  substrait_call_agg(
+    "aggregate_approx.approx_count_distinct",
+    x,
+    .output_type = substrait_i64(),
+    .phase = 3L,
+    .invocation = 1L
+  )
 }
 
 check_na_rm <- function(na.rm) {

--- a/R/pkg-arrow.R
+++ b/R/pkg-arrow.R
@@ -291,6 +291,11 @@ arrow_funs[["grepl"]] <- function(pattern, x, ...) {
   substrait_call("string.contains", x, pattern)
 }
 
+arrow_funs[["n_distinct"]] <- function(..., na.rm = FALSE) {
+  check_na_rm(na.rm)
+  substrait_call_agg("aggregate_approx.approx_count_distinct", ..., .output_type = substrait_i64(), .phase = 3L, .invocation = 1L)
+}
+
 check_na_rm <- function(na.rm) {
   if (!na.rm) {
     warning("Missing value removal from aggregate functions not yet supported, switching to na.rm = TRUE")

--- a/R/pkg-duckdb.R
+++ b/R/pkg-duckdb.R
@@ -287,6 +287,11 @@ duckdb_funs[["grepl"]] <- function(pattern, x) {
   substrait_call("contains", x, pattern)
 }
 
+duckdb_funs[["n_distinct"]] <- function(x, na.rm = FALSE) {
+  check_na_rm_duckdb(na.rm)
+  substrait_call_agg("approx_count_distinct", x, .output_type = substrait_i64())
+}
+
 check_na_rm_duckdb <- function(na.rm) {
   if (!na.rm) {
     warning("Missing value removal from aggregate functions not supported in DuckDB, switching to na.rm = TRUE")

--- a/R/pkg-duckdb.R
+++ b/R/pkg-duckdb.R
@@ -289,6 +289,8 @@ duckdb_funs[["grepl"]] <- function(pattern, x) {
 
 duckdb_funs[["n_distinct"]] <- function(x, na.rm = FALSE) {
   check_na_rm_duckdb(na.rm)
+  warn_n_distinct()
+
   substrait_call_agg("approx_count_distinct", x, .output_type = substrait_i64())
 }
 
@@ -296,4 +298,13 @@ check_na_rm_duckdb <- function(na.rm) {
   if (!na.rm) {
     warning("Missing value removal from aggregate functions not supported in DuckDB, switching to na.rm = TRUE")
   }
+}
+
+warn_n_distinct <- function() {
+  rlang::warn(
+    "n_distinct() currently returns an approximate count",
+    .frequency = "once",
+    .frequency_id = "substrait.n_distinct.approximate",
+    class = "substrait.n_distinct.approximate"
+  )
 }

--- a/tests/testthat/test-pkg-arrow.R
+++ b/tests/testthat/test-pkg-arrow.R
@@ -659,7 +659,21 @@ test_that("arrow translation for if_else() works", {
     tibble::tibble(
       dbl = c(-999, -99, -9, 0, 9),
       gt_five = c("under", "under", "under", "under", "over")
+    )
+  )
+})
 
+test_that("arrow translation for n_distinct works", {
+  skip_if_not(has_arrow_with_substrait())
+  skip("Substrait function `approx_count_distinct` not yet implemented in Arrow C++")
+
+  expect_equal(
+    tibble::tibble(x = c(1:5, 1:3)) %>%
+      arrow_substrait_compiler() %>%
+      substrait_aggregate(n = n_distinct(x, na.rm = TRUE)) %>%
+      dplyr::collect(),
+    tibble::tibble(
+      n = 5
     )
   )
 })

--- a/tests/testthat/test-pkg-arrow.R
+++ b/tests/testthat/test-pkg-arrow.R
@@ -662,18 +662,3 @@ test_that("arrow translation for if_else() works", {
     )
   )
 })
-
-test_that("arrow translation for n_distinct works", {
-  skip_if_not(has_arrow_with_substrait())
-  skip("Substrait function `approx_count_distinct` not yet implemented in Arrow C++")
-
-  expect_equal(
-    tibble::tibble(x = c(1:5, 1:3)) %>%
-      arrow_substrait_compiler() %>%
-      substrait_aggregate(n = n_distinct(x, na.rm = TRUE)) %>%
-      dplyr::collect(),
-    tibble::tibble(
-      n = 5
-    )
-  )
-})

--- a/tests/testthat/test-pkg-duckdb.R
+++ b/tests/testthat/test-pkg-duckdb.R
@@ -338,3 +338,17 @@ test_that("duckdb translation for if_else() works", {
     )
   )
 })
+
+test_that("duckdb translation for n_distinct works", {
+  skip_if_not(has_duckdb_with_substrait())
+
+  expect_equal(
+    tibble::tibble(x = c(1:5, 1:3)) %>%
+      duckdb_substrait_compiler() %>%
+      substrait_aggregate(n = n_distinct(x, na.rm = TRUE)) %>%
+      dplyr::collect(),
+    tibble::tibble(
+      n = 5
+    )
+  )
+})

--- a/tests/testthat/test-pkg-duckdb.R
+++ b/tests/testthat/test-pkg-duckdb.R
@@ -342,13 +342,16 @@ test_that("duckdb translation for if_else() works", {
 test_that("duckdb translation for n_distinct works", {
   skip_if_not(has_duckdb_with_substrait())
 
-  expect_equal(
-    tibble::tibble(x = c(1:5, 1:3)) %>%
-      duckdb_substrait_compiler() %>%
-      substrait_aggregate(n = n_distinct(x, na.rm = TRUE)) %>%
-      dplyr::collect(),
-    tibble::tibble(
-      n = 5
-    )
+  suppressWarnings(
+    expect_equal(
+      tibble::tibble(x = c(1:5, 1:3)) %>%
+        duckdb_substrait_compiler() %>%
+        substrait_aggregate(n = n_distinct(x, na.rm = TRUE)) %>%
+        dplyr::collect(),
+      tibble::tibble(
+        n = 5
+      )
+    ),
+    classes = "substrait.n_distinct.approximate"
   )
 })


### PR DESCRIPTION
Fixes #145 

``` r
library(substrait)
library(dplyr)

mtcars %>%
  duckdb_substrait_compiler() %>%
  summarise(n = n_distinct(am, na.rm = TRUE)) %>%
  collect()
#> # A tibble: 1 × 1
#>       n
#>   <int>
#> 1     2

# not currently supported in Arrow C++
mtcars %>%
  arrow_substrait_compiler() %>%
  summarise(n = n_distinct(am, na.rm = TRUE)) %>%
  collect()
#> Error: NotImplemented: No conversion function exists to convert the Substrait aggregate function approx_count_distinct to an Arrow call expression
#> /home/nic2/arrow/cpp/src/arrow/engine/substrait/relation_internal.cc:643  ext_set.registry()->GetSubstraitAggregateToArrowFallback( aggregate_call.id().name)
#> /home/nic2/arrow/cpp/src/arrow/engine/substrait/serde.cc:158  FromProto(plan_rel.has_root() ? plan_rel.root().input() : plan_rel.rel(), ext_set, conversion_options)
```


