### PR TITLE
Update Arrow version to latest (at time of PR) on main branch

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -35,7 +35,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
       ARROW_R_DEV: TRUE
-      ARROW_REF: '54e17920eee65e4227eba889aadbdfeb66c114cd'
+      ARROW_REF: '7db7e6ac846199678e2694f173df6dd6376ee823'
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This PR updates the version of Arrow to commit `7db7e6ac846199678e2694f173df6dd6376ee823`.  This is needed to be able to use the mapping for the Substrait `round()` function that we want to create a dplyr binding for.