### PR TITLE
Remove deprecated dplyr usage

### DIFF
--- a/R/pkg-dplyr.R
+++ b/R/pkg-dplyr.R
@@ -258,7 +258,7 @@ relocate.SubstraitCompiler <- function(.data, ..., .before = NULL, .after = NULL
   has_after <- !rlang::quo_is_null(.after)
 
   if (has_before && has_after) {
-    rlang::abort("Must supply only one of `.before` and `.after`.")
+    rlang::abort("Can't supply both `.before` and `.after`.")
   } else if (has_before) {
     where <- min(unname(tidyselect::eval_select(.before, simulate_data_frame(.data))))
     if (!where %in% to_move) {

--- a/tests/testthat/test-dplyr-filter.R
+++ b/tests/testthat/test-dplyr-filter.R
@@ -382,7 +382,7 @@ test_that("filter() with .data pronoun", {
     engine = "duckdb",
     .input %>%
       filter(.data$dbl == 4) %>%
-      select(.data$chr, .data$int, .data$lgl) %>%
+      select(chr, int, lgl) %>%
       collect(),
     example_data
   )
@@ -393,7 +393,7 @@ test_that("filter() with .data pronoun", {
     engine = "duckdb",
     .input %>%
       filter(is.na(.data$lgl)) %>%
-      select(.data$chr, .data$int, .data$lgl) %>%
+      select(chr, int, lgl) %>%
       collect(),
     example_data
   )
@@ -405,7 +405,7 @@ test_that("filter() with .data pronoun", {
     engine = "duckdb",
     .input %>%
       filter(.data$dbl < .env$chr) %>%
-      select(.data$chr, .data$int, .data$lgl) %>%
+      select(chr, int, lgl) %>%
       collect(),
     example_data
   )
@@ -415,7 +415,7 @@ test_that("filter() with .data pronoun", {
     engine = "duckdb",
     .input %>%
       filter(.data$dbl < .env[["chr"]]) %>%
-      select(.data$chr, .data$int, .data$lgl) %>%
+      select(chr, int, lgl) %>%
       collect(),
     example_data
   )

--- a/tests/testthat/test-dplyr-select.R
+++ b/tests/testthat/test-dplyr-select.R
@@ -154,9 +154,11 @@ test_that("relocate with selection helpers", {
     example_data
   )
 
-  compare_dplyr_error(
-    .input %>% relocate(int, lgl, .before = where(is.numeric), .after = dbl) %>% collect(),
-    example_data,
+  expect_error(
+    example_data %>%
+      substrait_compiler() %>%
+      relocate(int, lgl, .before = where(is.numeric), .after = dbl),
+    regexp = "Can't supply both `.before` and `.after`.",
     fixed = TRUE
   )
 


### PR DESCRIPTION
Remove deprecated usage of the `.data` pronoun in calls to `select()` and update a test which is causing failures on the main branch.