### PR TITLE
Add duckdb bindings for sqrt, abs, exp, and sign

### DIFF
--- a/R/pkg-duckdb.R
+++ b/R/pkg-duckdb.R
@@ -259,6 +259,62 @@ duckdb_funs[["^"]] <- function(lhs, rhs) {
   substrait_call("^", lhs, rhs, .output_type = function(lhs, rhs) lhs)
 }
 
+duckdb_funs[["sqrt"]] <- function(x) {
+  substrait_call(
+    "sqrt",
+    x,
+    .output_type = substrait_fp64(),
+    .options = list(
+      substrait$FunctionOption$create(
+        name = "overflow",
+        preference = "SILENT"
+      )
+    )
+  )
+}
+
+duckdb_funs[["abs"]] <- function(x) {
+  substrait_call(
+    "abs",
+    x,
+    .output_type = function(x) x,
+    .options = list(
+      substrait$FunctionOption$create(
+        name = "overflow",
+        preference = "SILENT"
+      )
+    )
+  )
+}
+
+duckdb_funs[["exp"]] <- function(x) {
+  substrait_call(
+    "exp",
+    x,
+    .output_type = substrait_fp64(),
+    .options = list(
+      substrait$FunctionOption$create(
+        name = "overflow",
+        preference = "SILENT"
+      )
+    )
+  )
+}
+
+duckdb_funs[["sign"]] <- function(x) {
+  substrait_call(
+    "sign",
+    x,
+    .output_type = substrait_fp64(),
+    .options = list(
+      substrait$FunctionOption$create(
+        name = "overflow",
+        preference = "SILENT"
+      )
+    )
+  )
+}
+
 duckdb_funs[["sum"]] <- function(x, na.rm = FALSE) {
   check_na_rm_duckdb(na.rm)
   substrait_call_agg("sum", x, .output_type = identity)

--- a/tests/testthat/test-pkg-duckdb.R
+++ b/tests/testthat/test-pkg-duckdb.R
@@ -404,3 +404,51 @@ test_that("duckdb translation for round works", {
     )
   )
 })
+
+test_that("duckdb translation for sqrt() works", {
+  skip_if_not(has_duckdb_with_substrait())
+
+  expect_equal(
+    tibble::tibble(x = c(1, 2, 3, 4)) %>%
+      duckdb_substrait_compiler() %>%
+      substrait_project(x = sqrt(x)) %>%
+      dplyr::collect(),
+    tibble::tibble(x = c(1, 1.4142135623731, 1.73205080756888, 2))
+  )
+})
+
+test_that("duckdb translation for abs() works", {
+  skip_if_not(has_duckdb_with_substrait())
+
+  expect_equal(
+    tibble::tibble(x = c(-1, -2, 3, 4)) %>%
+      duckdb_substrait_compiler() %>%
+      substrait_project(x = abs(x)) %>%
+      dplyr::collect(),
+    tibble::tibble(x = 1:4)
+  )
+})
+
+test_that("duckdb translation for exp() works", {
+  skip_if_not(has_duckdb_with_substrait())
+
+  expect_equal(
+    tibble::tibble(x = c(1, 2, 3, 4)) %>%
+      duckdb_substrait_compiler() %>%
+      substrait_project(x = exp(x)) %>%
+      dplyr::collect(),
+    tibble::tibble(x = c(2.71828182845905, 7.38905609893065, 20.0855369231877, 54.5981500331442))
+  )
+})
+
+test_that("duckdb translation for sign() works", {
+  skip_if_not(has_duckdb_with_substrait())
+
+  expect_equal(
+    tibble::tibble(x = c(-1, -2, 0, 4)) %>%
+      duckdb_substrait_compiler() %>%
+      substrait_project(x = sign(x)) %>%
+      dplyr::collect(),
+    tibble::tibble(x = c(-1, -1, 0, 1))
+  )
+})


### PR DESCRIPTION
This PR adds bindings for the DuckDB Substrait compiler for functions `sqrt()`, `abs()`, `exp()`, and `sign()`.