### PR TITLE
Fix error with calling select() on a date column

### DIFF
--- a/R/literal.R
+++ b/R/literal.R
@@ -95,6 +95,7 @@ from_substrait.vctrs_unspecified <- function(msg, x, ...) {
         "i32" = integer(),
         "fp64" = double(),
         "string" = character(),
+        "date" = structure(numeric(0), class = "Date"),
         stop(sprintf("Can't convert substrait.Type<%s> to ptype<any>", type))
       )
     },

--- a/tests/testthat/test-pkg-dplyr.R
+++ b/tests/testthat/test-pkg-dplyr.R
@@ -404,3 +404,13 @@ test_that("distinct.SubstraitCompiler works", {
   expect_named(out$groups, "b")
   expect_equal(get_grouping_fields(agg$groupings[[1]]), list(1, 2))
 })
+
+test_that("select() works on date columns", {
+  skip_if_not_installed("dplyr")
+
+  df <- data.frame(x = as.Date("2012-09-16"))
+  compiler <- substrait_compiler(df)
+  out <- compiler %>%
+    select(x)
+  expect_named(out$.data, "x")
+})


### PR DESCRIPTION
Fixes #265 

Before:

```
library(substrait)
library(dplyr)
tibble::tibble(x = as.Date("1987-10-09")) %>%
  duckdb_substrait_compiler() %>%
  select(x)
#> Error in from_substrait.vctrs_unspecified(dots[[1L]][[1L]], dots[[2L]][[1L]]): Can't convert substrait.Type<date> to ptype<any>
```
After: 
``` r
library(substrait)
library(dplyr)

tibble::tibble(x = as.Date("1987-10-09")) %>%
  duckdb_substrait_compiler() %>%
  select(x)
#> <DuckDBSubstraitCompiler>
#>   Inherits from: <SubstraitCompiler>
#>   Public:
#>     .agg_functions: sum mean max min n n_distinct
#>     .data: list
#>     .fns: list
#>     add_named_table: function (object, ...) 
#>     add_relation: function (object, ...) 
#>     clone: function (deep = FALSE) 
#>     eval_mask: function (.data = TRUE) 
#>     evaluate: function (...) 
#>     extension_uri_anchor: function (name) 
#>     function_extension: function (id) 
#>     function_id: function (name, arg_types) 
#>     groups: NULL
#>     initialize: function (...) 
#>     named_table: function (name) 
#>     named_table_list: function () 
#>     next_id: function () 
#>     plan: function () 
#>     rel: substrait_Rel, substrait_proto_message, substrait_proto
#>     resolve_function: function (name, args, template, output_type = NULL, options = NULL) 
#>     schema: substrait_NamedStruct, substrait_proto_message, substrait_proto
#>     validate: function () 
#>   Private:
#>     extension_uri: list
#>     function_extensions: list
#>     function_extensions_key: list
#>     id_counter: 2
#>     named_tables: list
#>     type_extensions: list
#>     type_variations: list
```

<sup>Created on 2023-03-28 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
